### PR TITLE
pci: Enable bus-master on virtio_blk

### DIFF
--- a/drivers/pci.c
+++ b/drivers/pci.c
@@ -816,6 +816,9 @@ int virtio_blk_config_cb(const pci_config_t *config)
 		return 0;
 	}
 
+	/* Enable bus mastering to ensure vring processing will run. */
+	ob_pci_enable_bus_master(config);
+
 	ob_virtio_init(config->path, "virtio-blk", common_cfg, device_cfg,
 					notify_base, notify_mult, idx);
 #endif


### PR DESCRIPTION
In qemu 9d7bd0826f2d19f88631ad7078662668148f7b5f, the behavior of vring
processing was changed to not run whenever bus-mastering is disabled.

Since we were never enabling it in the first place, OpenBIOS was no longer
able to access virtio disks on qemu.

Fix this by enabling bus-mastering before initializing.

Signed-off-by: Brandon Bergren <git@bdragon.rtk0.net>