### PR TITLE
40p: Match QEMU Raven IRQ swizzling change

### DIFF
--- a/drivers/pci.c
+++ b/drivers/pci.c
@@ -1991,7 +1991,7 @@ static void ob_pci_host_bus_interrupt(ucell dnode, u32 *props, int *ncells, u32 
 {
     *ncells += pci_encode_phys_addr(props + *ncells, 0, 0, addr, 0, 0);
 
-    if (is_oldworld() || is_newworld()) {
+    if (is_apple()) {
         /* Mac machines */
         props[(*ncells)++] = intno;
         props[(*ncells)++] = dnode;

--- a/drivers/pci.c
+++ b/drivers/pci.c
@@ -1991,28 +1991,15 @@ static void ob_pci_host_bus_interrupt(ucell dnode, u32 *props, int *ncells, u32 
 {
     *ncells += pci_encode_phys_addr(props + *ncells, 0, 0, addr, 0, 0);
 
-    if (is_apple()) {
-        /* Mac machines */
-        props[(*ncells)++] = intno;
-        props[(*ncells)++] = dnode;
-        props[(*ncells)++] = arch->irqs[((intno - 1) + (addr >> 11)) & 3];
-        props[(*ncells)++] = 1;
+    props[(*ncells)++] = intno;
+    props[(*ncells)++] = dnode;
+    if (!is_apple() && (PCI_DEV(addr) == 1 && PCI_FN(addr) == 0)) {
+        /* On PReP machine the LSI SCSI has fixed routing to IRQ 13 */
+        props[(*ncells)++] = 13;
     } else {
-        /* PReP machines */
-        props[(*ncells)++] = intno;
-        props[(*ncells)++] = dnode;
-
-        if (PCI_DEV(addr) == 1 && PCI_FN(addr) == 0) {
-            /* LSI SCSI has fixed routing to IRQ 13 */
-            props[(*ncells)++] = 13;
-        } else {
-            /* Use the same "physical" routing as QEMU's raven_map_irq() although
-               ultimately all 4 PCI interrupts are ORd to IRQ 15 as indicated
-               by the PReP specification */
-            props[(*ncells)++] = arch->irqs[((intno - 1) + (addr >> 11)) & 3];
-        }
-        props[(*ncells)++] = 1;
+        props[(*ncells)++] = arch->irqs[((intno - 1) + (addr >> 11)) & 3];
     }
+    props[(*ncells)++] = 1;
 }
 
 #elif defined(CONFIG_SPARC64)

--- a/drivers/pci.c
+++ b/drivers/pci.c
@@ -2009,7 +2009,7 @@ static void ob_pci_host_bus_interrupt(ucell dnode, u32 *props, int *ncells, u32 
             /* Use the same "physical" routing as QEMU's raven_map_irq() although
                ultimately all 4 PCI interrupts are ORd to IRQ 15 as indicated
                by the PReP specification */
-            props[(*ncells)++] = arch->irqs[((intno - 1) + (addr >> 11)) & 1];
+            props[(*ncells)++] = arch->irqs[((intno - 1) + (addr >> 11)) & 3];
         }
         props[(*ncells)++] = 1;
     }


### PR DESCRIPTION
As requested by Mark on qemu-devel list, update OpenBIOS to be
consistent with QEMU change:
https://lists.gnu.org/archive/html/qemu-devel/2020-10/msg03079.html