### PR TITLE
libopenbios: fix incorrect size for ELF header

### DIFF
--- a/libopenbios/elf_load.c
+++ b/libopenbios/elf_load.c
@@ -335,7 +335,7 @@ find_elf(Elf_ehdr *ehdr)
    int offset;
 
    for (offset = 0; offset < MAX_HEADERS * BS; offset += BS) {
-        if ((size_t)read_io(fd, ehdr, sizeof ehdr) != sizeof ehdr) {
+        if ((size_t)read_io(fd, ehdr, sizeof *ehdr) != sizeof *ehdr) {
             debug("Can't read ELF header\n");
             return 0;
         }


### PR DESCRIPTION
Sorry about the Github commit. I seem to have trouble with mailman today.

`find_elf()` would only load `sizeof(Elf_ehdr *)` (size of pointer, not the struct) bytes from a boot device, causing comparison `ehdr->e_type == ET_EXEC` to always fail on my machine due to uninitialized memory.