### PR TITLE
config/scripts/switch-arch: Enable building from aarch64, riscv64.

### DIFF
--- a/config/scripts/switch-arch
+++ b/config/scripts/switch-arch
@@ -38,7 +38,8 @@ longbits()
     if test "$cpu" = "sparc64" -o "$cpu" = "ia64" \
         -o "$cpu" = "amd64" -o "$cpu" = "x86_64" \
         -o "$cpu" = "powerpc64" -o "$cpu" = "ppc64" \
-        -o "$cpu" = "ppc64le" -o "$cpu" = "alpha" ; then
+        -o "$cpu" = "ppc64le" -o "$cpu" = "alpha" \
+        -o "$cpu" = "aarch64" -o "$cpu" = "riscv64" ; then
         echo 64
     else
         echo 32


### PR DESCRIPTION
aarch64 and riscv64 are 64-bit CPUs, and without configuring the longbits as 64 writing the dictionary core file would fail with a segfault.