### PR TITLE
arch/unix/unix.c: Avoid unused-result warning

### DIFF
--- a/arch/unix/unix.c
+++ b/arch/unix/unix.c
@@ -419,7 +419,8 @@ read_from_disk( int channel, int unit, int blk, unsigned long mphys, int size )
 	//		channel, unit, blk, mphys, size);
 
 	lseek(diskemu, (ducell)blk*512, SEEK_SET);
-	read(diskemu, buf, size);
+	if(read(diskemu, buf, size)==-1)
+		return -1;
 
 	return 0;
 }


### PR DESCRIPTION
```
  CC    target/arch/unix/unix.o
/build/source/arch/unix/unix.c: In function 'read_from_disk':
/build/source/arch/unix/unix.c:422:9: error: ignoring return value of 'read' declared with attribute 'warn_unused_result' [8;;https://gcc.gnu.org/onlinedocs/gcc-14.3.0/gcc/Warning-Options.html#index-Wno-unused-result-Werror=unused-result8;;]
  422 |         read(diskemu, buf, size);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[1]: *** [rules.mak:209: target/arch/unix/unix.o] Error 1
```

[`read()` returns either the amount of actually read bytes, or -1 in case of an error](https://pubs.opengroup.org/onlinepubs/9699919799/functions/read.html). Check return value, propagate error.