### PR TITLE
ppc: bump SAVE_SPACE to include enough space to store all registers

### DIFF
--- a/arch/ppc/qemu/start.S
+++ b/arch/ppc/qemu/start.S
@@ -503,7 +503,7 @@ _GLOBAL(saved_stack):
 #define SAVE_SPACE 320
 #else
 #define STKOFF 8
-#define SAVE_SPACE 144
+#define SAVE_SPACE 156
 #endif
 
 GLOBL(of_client_callback):


### PR DESCRIPTION
It looks like SAVE_SPACE at 144 bytes isn't enough to store all the registers - r29, r30 and r31 end up wrapping the 32 bit stack pointer around to 0x0.

See https://github.com/openbios/openbios/issues/27 for more information.